### PR TITLE
Changed Militia Carrier License to just Militia License since the Mil…

### DIFF
--- a/boarding-enhancements/data/outfits.txt
+++ b/boarding-enhancements/data/outfits.txt
@@ -112,7 +112,7 @@ outfit "Small Armory"
 	"outfit space" -10
 	description "The Small Armory provides an assortment of offensive and defensive weapons that are securely stored and readily available, in the event you are boarding or being boarded. A built-in weapons training area improves combat effectiveness of the crew. Obviously, no government encourages civilian possession of such small arsenal and training facilities, so purchasing these is restricted to detachments of Militia and Navy."
 	licenses
-		"Militia Carrier"
+		"Militia"
 
 outfit "Large Armory"
 	plural "Large Armories"


### PR DESCRIPTION
Changed Militia Carrier License to just Militia License since the Militia Carrier License was removed, and is no longer granted by the FW campaign. Only the Militia license is ever granted.